### PR TITLE
Client-side image downsize using the Canvas API

### DIFF
--- a/app/src/js/image.js
+++ b/app/src/js/image.js
@@ -1,0 +1,38 @@
+/**
+ * Obtains image dimensions from an <img> Element
+ * @param {HTMLImageElement} image element
+ * @returns Promise<{ height, width }>
+ */
+export function getImageDimensions(image) {
+  return new Promise((resolve, _reject) => {
+      image.onload = function(_error){
+          const width = this.width
+          const height = this.height
+          resolve({ height, width })
+      }
+  })
+}
+
+/**
+ * Compresses an image using the Canvas API
+ * @param {HTMLImageElement} image element
+ * @param {*} scale Scale of the compressed image, between 0-1
+ * @param {*} initialWidth Initial width of uncompressed image
+ * @param {*} initialHeight Initial height of uncompressed
+ * @returns Promise blob
+ */
+export function compressImage(image, scale, initialWidth, initialHeight){
+  return new Promise((resolve, _reject) => {
+      const canvas = document.createElement("canvas")
+
+      canvas.width = scale * initialWidth
+      canvas.height = scale * initialHeight
+
+      const ctx = canvas.getContext("2d")
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+      ctx.canvas.toBlob((blob) => {
+          resolve(blob)
+      }, "image/jpeg")
+  })
+}

--- a/app/src/public/listing.js
+++ b/app/src/public/listing.js
@@ -1,3 +1,42 @@
+/**
+ * Obtains image dimensions from an <img> Element
+ * @param {HTMLImageElement} image element
+ * @returns Promise<{ height, width }>
+ */
+function getImageDimensions(image) {
+  return new Promise((resolve, _reject) => {
+      image.onload = function(_error){
+          const width = this.width;
+          const height = this.height;
+          resolve({ height, width });
+      };
+  })
+}
+
+/**
+ * Compresses an image using the Canvas API
+ * @param {HTMLImageElement} image element
+ * @param {*} scale Scale of the compressed image, between 0-1
+ * @param {*} initialWidth Initial width of uncompressed image
+ * @param {*} initialHeight Initial height of uncompressed
+ * @returns Promise blob
+ */
+function compressImage(image, scale, initialWidth, initialHeight){
+  return new Promise((resolve, _reject) => {
+      const canvas = document.createElement("canvas");
+
+      canvas.width = scale * initialWidth;
+      canvas.height = scale * initialHeight;
+
+      const ctx = canvas.getContext("2d");
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+      ctx.canvas.toBlob((blob) => {
+          resolve(blob);
+      }, "image/jpeg");
+  })
+}
+
 console.log('Start');
 
 const overlay = document.querySelector('.overlay');
@@ -44,19 +83,51 @@ if (document.querySelector('form.listing')) {
   setTimeout(checkSubmit, 1000); // Timeout to check for browser autofill
 
   console.log('Creating checks to display image preview if file selected');
-  const preview = document.getElementsByClassName('preview')[0];
-  const fileChange = document.getElementsByClassName('change')[0];
+  const [ preview ] = document.getElementsByClassName('preview');
+  const [ fileChange ] = document.getElementsByClassName('change');
   const fileInput = document.getElementById('file');
-  const checkFile = () => {
+
+  const checkFile = async () => {
     console.log('checkFile: Start');
-    const [file] = fileInput.files;
-    if (file) {
+
+    const [ uploadedImage ] = fileInput.files;
+
+    if (uploadedImage) {
       console.log('checkFile: File selected. Displaying preview');
-      preview.src = URL.createObjectURL(file);
+      // HTMLImageElement to hold the uploaded image temporarily
+      const temp = document.createElement('img');
+      temp.src = URL.createObjectURL(uploadedImage);
+
+      // Obtain dimensions
+      const { height, width } = await getImageDimensions(temp);
+
+      // Compression
+      const MAX_WIDTH = 1024; // if we resize by width, this is the max width of compressed image
+      const MAX_HEIGHT = 1024; // if we resize by height, this is the max height of the compressed image
+
+      const widthRatioBlob = await compressImage(temp, MAX_WIDTH / width, width, height);
+      const heightRatioBlob = await compressImage(temp, MAX_HEIGHT / height, width, height);
+
+      // Pick the smaller blob between both
+      const compressedBlob = widthRatioBlob.size > heightRatioBlob.size ? heightRatioBlob : widthRatioBlob;
+
+      // Reuse the uploaded image in case the uploaded image is smaller than our compressed result.
+      const optimalBlob = compressedBlob.size < uploadedImage.size ? compressedBlob : uploadedImage;
+
+      // Display the compressed image
+      preview.src = URL.createObjectURL(optimalBlob);
+
+      console.log(`Initial size: ${uploadedImage.size}. Compressed size: ${optimalBlob.size}`);
+
+      // Display file
       preview.classList.remove('hidden');
       fileChange.classList.remove('hidden');
+
+      // Cleanup
+      URL.revokeObjectURL(temp.src);
     }
   };
+
   checkFile();
   fileInput?.addEventListener('change', checkFile);
   setTimeout(checkFile, 1000); // Timeout to check for browser autofill


### PR DESCRIPTION
## Implementation
This PR implements a lossy resize of uploaded images to a maximum of 1024 x 1024 px by using the canvas to resize the image.

## Alternatives
An alternative implementation would be to use the [browser-image-compression](https://www.npmjs.com/package/browser-image-compression) library. It works similarly under the hood, but has additional features to (a) achieve a target size of 1mb by repeatedly compressing the image by 5% each time (b) offload the work to a _WebWorker_ and _OffscreenCanvas_ which offloads computation from the main thread.